### PR TITLE
CINT-2434 - CDN Integration - Cloudflare & others - Update Example Value for errorUrl

### DIFF
--- a/cdn-examples/server/akamai-edgeworker/proxy/main.js
+++ b/cdn-examples/server/akamai-edgeworker/proxy/main.js
@@ -5,6 +5,7 @@
  * This requires the following variables being setup for the Akamai Property User variables
  * @param {string} privateKey The Arkose Labs private key to use for verification
  * @param {string} errorUrl A url to redirect to if there has been an error
+ * IMPORTANT: Before using, set 'errorUrl' to the URL for error redirection
  * @param {string} tokenIdentifier The property name for the header / cookie that contains the Arkose Labs token
  * @param {string} tokenMethod The storage method of the Arkose Labs token, this can be either "header" or "cookie".
  * @param {string} failOpen A boolean string to indicate if the current session should fail
@@ -140,7 +141,7 @@ const getArkoseToken = (request, tokenMethod, tokenIdentifier) => {
 
 export async function responseProvider(request) {
   const privateKey = request.getVariable('PMUSER_ARKOSE_PRIVATE_KEY');
-  const errorUrl = request.getVariable('PMUSER_ERROR_URL');
+  const errorUrl = request.getVariable('PMUSER_ERROR_URL'); // Set this to your error handling URL
   const tokenIdentifier = request.getVariable('PMUSER_TOKEN_IDENTIFIER');
   const tokenMethod = request.getVariable('PMUSER_TOKEN_METHOD');
   const failOpen = parseBoolean(request.getVariable('PMUSER_FAIL_OPEN'));
@@ -198,10 +199,10 @@ export async function responseProvider(request) {
     // If session is not verified and Arkose does not have an outage, handle failure
     return createResponse(
       302,
-      { Location: [errorUrl] },
+      { Location: [errorUrl] }, // Set this to your error handling URL
       'Session is not verified and Arkose is healthy'
     );
   }
   // If no token is found, handle failure
-  return createResponse(302, { Location: [errorUrl] }, 'No token found');
+  return createResponse(302, { Location: [errorUrl] }, 'No token found'); // Set this to your error handling URL
 }

--- a/cdn-examples/server/auth0/DX/index.js
+++ b/cdn-examples/server/auth0/DX/index.js
@@ -11,6 +11,7 @@
  * @param {string} clientSubdomain A customer's specific subdomain used for the loading of the Client-API (if setup)
  * @param {string} verifySubdomain A customer's specific subdomain used for the verification call (if setup)
  * @param {string} errorUrl A url to redirect to if there has been an error
+ * IMPORTANT: Before using, set 'errorUrl' to the URL for error redirection
  * @param {string} cookieName The name of the cookie to store the Arkose Labs session token in
  * @param {string} failOpen A boolean string to indicate if the current session should fail
  * open if there is a problem with the Arkose Labs platform.
@@ -134,10 +135,11 @@ const verifyArkoseToken = async (
 /**
  * Handles failures to verify and redirects to a specified url
  * @param  {string} errorUrl A string representing a url to redirect to on failure
+ * IMPORTANT: Before using, set 'errorUrl' to the URL for error redirection
  * @return {Object} The response to handle the error
  */
 const handleFailure = (errorUrl) => {
-  return Response.redirect(errorUrl, '301');
+  return Response.redirect(errorUrl, '301'); // Set this to your error handling URL
 };
 
 /**
@@ -242,7 +244,7 @@ export default {
     const { privateKey } = env;
     const { clientSubdomain = 'client-api' } = env;
     const { verifySubdomain = 'verify-api' } = env;
-    const { errorUrl } = env;
+    const { errorUrl } = env; // Set this to your error handling URL
     const { arkoseCookieName = 'arkoseToken' } = env;
     const { arkoseErrorCookieName = 'arkoseError' } = env;
     const arkoseCookieLife = parseNumber(env.arkoseCookieLife);
@@ -465,14 +467,14 @@ export default {
       }
       // If session is not verified and Arkose does not have an outage, handle failure
       if (tokenEnforcement) {
-        return handleFailure(errorUrl);
+        return handleFailure(errorUrl); // Set this to your error handling URL
       }
       const response = await fetch(request);
       return checkResponse(response);
     }
     // If no token is found, handle failure
     if (tokenEnforcement) {
-      return handleFailure(errorUrl);
+      return handleFailure(errorUrl); // Set this to your error handling URL
     }
     const response = await fetch(request);
     return checkResponse(response);

--- a/cdn-examples/server/auth0/index.js
+++ b/cdn-examples/server/auth0/index.js
@@ -9,6 +9,7 @@
  * @param {string} clientSubdomain A customer's specific subdomain used for the loading of the Client-API (if setup)
  * @param {string} verifySubdomain A customer's specific subdomain used for the verification call (if setup)
  * @param {string} errorUrl A url to redirect to if there has been an error
+ * IMPORTANT: Before using, set 'errorUrl' to the URL for error redirection
  * @param {string} arkoseCookieLife  The length of time the Arkose cookies should be active for (in milliseconds) 
 |* @param {string} arkoseCookieName The name of the cookie that the Arkose token will be stored in
 |* @param {string} arkoseErrorCookieName The name of the cookie that an Arkose error will be stored in
@@ -131,10 +132,11 @@ const verifyArkoseToken = async (
 /**
  * Handles failures to verify and redirects to a specified url
  * @param  {string} errorUrl A string representing a url to redirect to on failure
+ * IMPORTANT: Before using, set 'errorUrl' to the URL for error redirection
  * @return {Object} The response to handle the error
  */
 const handleFailure = (errorUrl) => {
-  return Response.redirect(errorUrl, '301');
+  return Response.redirect(errorUrl, '301'); // Set this to your error handling URL
 };
 
 export default {
@@ -143,7 +145,7 @@ export default {
     const { privateKey } = env;
     const { clientSubdomain = 'client-api' } = env;
     const { verifySubdomain = 'verify-api' } = env;
-    const { errorUrl } = env;
+    const { errorUrl } = env; // Set this to your error handling URL
     const { arkoseCookieName = 'arkoseToken' } = env;
     const { arkoseErrorCookieName = 'arkoseError' } = env;
     const arkoseCookieLife = parseNumber(env.arkoseCookieLife);
@@ -348,9 +350,9 @@ export default {
         return checkResponse(response);
       }
       // If session is not verified and Arkose does not have an outage, handle failure
-      return handleFailure(errorUrl);
+      return handleFailure(errorUrl); // Set this to your error handling URL
     }
     // If no token is found, handle failure
-    return handleFailure(errorUrl);
+    return handleFailure(errorUrl); // Set this to your error handling URL
   },
 };

--- a/cdn-examples/server/cloudflare-worker/index.js
+++ b/cdn-examples/server/cloudflare-worker/index.js
@@ -7,6 +7,7 @@
  * @param {string} privateKey The Arkose Labs private key to use for verification
  * @param {string} verifySubdomain A customer's specific subdomain used for the verification call (if setup)
  * @param {string} errorUrl A url to redirect to if there has been an error
+ * IMPORTANT: Before using, set 'errorUrl' to the URL for error redirection
  * @param {string} tokenMethod The storage method of the Arkose Labs token, this can be either "header" or "cookie".
  * @param {string} tokenIdentifier The property name for the header / cookie that contains the Arkose Labs token
  * @param {string} failOpen A boolean string to indicate if the current session should fail
@@ -155,7 +156,7 @@ const getArkoseToken = (request, tokenMethod, tokenIdentifier) => {
  * @return {Object} The response to handle the error
  */
 const handleFailure = (errorUrl) => {
-  return Response.redirect(errorUrl, '301');
+  return Response.redirect(errorUrl, '301'); // Set this to your error handling URL
 };
 
 
@@ -163,7 +164,7 @@ export default {
   async fetch(request, env) {
     const { privateKey } = env;
     const { verifySubdomain = 'client-api' } = env;
-    const { errorUrl } = env;
+    const { errorUrl } = env; // Set this to your error handling URL
     const { tokenIdentifier = 'arkose-token' } = env;
     const { tokenMethod = 'header' } = env;
     const failOpen = parseBoolean(env.failOpen);
@@ -194,9 +195,9 @@ export default {
       }
 
       // If session is not verified and Arkose does not have an outage, handle failure
-      return handleFailure(errorUrl);
+      return handleFailure(errorUrl); // Set this to your error handling URL
     }
     // If no token is found, handle failure
-    return handleFailure(errorUrl);
+    return handleFailure(errorUrl); // Set this to your error handling URL
   },
 };


### PR DESCRIPTION
## JIRA Ticket
https://arkoselabs.atlassian.net/browse/CINT-2434

## Overview
Make it clearer in documentation for CDN Integration to change `urlError`.

## Change summary
- Added in comments to make it clearer that the var `urlError` needs to be added as a env variable

## Does this PR introduce a breaking change?
No

## How has this been tested?
No - documentation only

## Related PRs (if applicable):
- https://github.com/ArkoseLabs/cdn-integration/pull/36

## External related documentation (if applicable):